### PR TITLE
Add tests on macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
     echo "Coverage not dealing with 'script'"
   else
     cargo doc --all
-    cargo test --all --verbose
+    cargo test --all --verbose -- --nocapture
   fi
 
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vlog"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Chen Weiguang <chen.weiguang@gmail.com>"]
 description = "Macros to do stdout / stderr logs based on verbosity level."
 documentation = "https://docs.rs/vlog"
@@ -14,8 +14,8 @@ license = "MIT"
 travis-ci = { repository = "guangie88/vlog-rs" }
 codecov = { repository = "guangie88/vlog-rs" }
 
-# [dev-dependencies]
-# gag = "0.1.10"
+[dev-dependencies]
+gag = "0.1.10"
 
 [lib]
 name = "vlog"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 # source: https://github.com/starkat99/appveyor-rust/blob/master/appveyor.yml
 # source: https://github.com/japaric/rust-everywhere/blob/master/appveyor.yml
 
-version: 0.1.3-build-{build}
+version: 0.1.4-build-{build}
 
 matrix:
   fast_finish: true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@
 //! }
 //! ```
 
+#[cfg(test)]
+extern crate gag;
+
 #[macro_use]
 mod macros;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+#[cfg(target_os = "linux")]
+use gag::BufferRedirect;
+#[cfg(target_os = "linux")]
+use std::io::Read;
+#[cfg(target_os = "linux")]
+use std::thread::sleep;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
 #[test]
 fn test_set_get() {
     set_verbosity_level(0);
@@ -13,4 +22,136 @@ fn test_set_get() {
 
     set_verbosity_level(3);
     assert_eq!(3, get_verbosity_level());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn test_macros() {
+    // This test has to be run without other tests being run since it depends on
+    // the stdout/stderr.
+    // While channel might be the better method, it is difficult to set up.
+    // It is much easier to just sleep long enough to make sure this runs last.
+
+    sleep(Duration::from_secs(1));
+
+    set_verbosity_level(0);
+
+    // stdout-0
+    {
+        let mut buf = BufferRedirect::stdout().unwrap();
+
+        v0!("{}{}", "stdout", "0");
+        v1!("{}{}", "stdout", "1");
+        v2!("{}{}", "stdout", "2");
+        v3!("{}{}", "stdout", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stdout0\n", &output);
+    }
+
+    // stderr-0
+    {
+        let mut buf = BufferRedirect::stderr().unwrap();
+
+        ve0!("{}{}", "stderr", "0");
+        ve1!("{}{}", "stderr", "1");
+        ve2!("{}{}", "stderr", "2");
+        ve3!("{}{}", "stderr", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stderr0\n", &output);
+    }
+
+    set_verbosity_level(1);
+
+    // stdout-1
+    {
+        set_verbosity_level(1);
+        let mut buf = BufferRedirect::stdout().unwrap();
+
+        v0!("{}{}", "stdout", "0");
+        v1!("{}{}", "stdout", "1");
+        v2!("{}{}", "stdout", "2");
+        v3!("{}{}", "stdout", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stdout0\nstdout1\n", &output);
+    }
+
+    // stderr-1
+    {
+        let mut buf = BufferRedirect::stderr().unwrap();
+
+        ve0!("{}{}", "stderr", "0");
+        ve1!("{}{}", "stderr", "1");
+        ve2!("{}{}", "stderr", "2");
+        ve3!("{}{}", "stderr", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stderr0\nstderr1\n", &output);
+    }
+
+    set_verbosity_level(2);
+
+    // stdout-2
+    {
+        let mut buf = BufferRedirect::stdout().unwrap();
+
+        v0!("{}{}", "stdout", "0");
+        v1!("{}{}", "stdout", "1");
+        v2!("{}{}", "stdout", "2");
+        v3!("{}{}", "stdout", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stdout0\nstdout1\nstdout2\n", &output);
+    }
+
+    // stderr-2
+    {
+        let mut buf = BufferRedirect::stderr().unwrap();
+
+        ve0!("{}{}", "stderr", "0");
+        ve1!("{}{}", "stderr", "1");
+        ve2!("{}{}", "stderr", "2");
+        ve3!("{}{}", "stderr", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stderr0\nstderr1\nstderr2\n", &output);
+    }
+
+    set_verbosity_level(3);
+
+    // stdout-3
+    {
+        let mut buf = BufferRedirect::stdout().unwrap();
+
+        v0!("{}{}", "stdout", "0");
+        v1!("{}{}", "stdout", "1");
+        v2!("{}{}", "stdout", "2");
+        v3!("{}{}", "stdout", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stdout0\nstdout1\nstdout2\nstdout3\n", &output);
+    }
+
+    // stderr-3
+    {
+        let mut buf = BufferRedirect::stderr().unwrap();
+
+        ve0!("{}{}", "stderr", "0");
+        ve1!("{}{}", "stderr", "1");
+        ve2!("{}{}", "stderr", "2");
+        ve3!("{}{}", "stderr", "3");
+
+        let mut output = String::new();
+        buf.read_to_string(&mut output).unwrap();
+        assert_eq!("stderr0\nstderr1\nstderr2\nstderr3\n", &output);
+    }
 }


### PR DESCRIPTION
The additional test is fairly unstable and only works on Linux, but somewhat worthwhile since it is the only means to test the macro calls in a unit test setting.

This forces the `cargo test` to require `-- --nocapture` on Linux test.